### PR TITLE
Changed URL used for Git Clone

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Enter the following credentials on the configuration page in the app
 `npm install -g @ionic/cli`
 
 #### Clone the repository
-`git clone git@github.com:MarvinvR/ombi-mobile.git`
+`git clone https://github.com/MarvinvR/ombi-mobile`
 
 #### Install dependencies
 `npm install`


### PR DESCRIPTION
Changed URL used to show how to clone repository. This is because the former method requires the use of Git with a public key, whereas using the link directly does not need SSH